### PR TITLE
Close waste chute door gently

### DIFF
--- a/P1P/change_filament_noAMS_P1P_0.4nozzle_v1.9.5.gcode
+++ b/P1P/change_filament_noAMS_P1P_0.4nozzle_v1.9.5.gcode
@@ -48,7 +48,9 @@ G1 E-20 F500
 M400 U1
 
 ; move away from chute and move back, credits to @Billiam for this section
-G1 X65 Y240 F12000
+G1 X120 F5000
+G1 Y240 F12000
+G1 X65
 G1 Y265 F3000
 
 ; don't know when next_extruder is >=255, so this may always activate?


### PR DESCRIPTION
Waste chute door lever is _inside_ the print head shroud. Original code moves straight down causing a loud noise and stress on the lever. In order to not break the lever or back panel of the printer (for P1S), we should move differently:

1. Move right to release the lever
2. Move down so print head is past lever
3. Move left in line with lever/waste chute
4. Move back to close door and position over waste chute